### PR TITLE
add previous*() functions to speed sensor reading

### DIFF
--- a/Adafruit_SHT31.h
+++ b/Adafruit_SHT31.h
@@ -14,6 +14,18 @@
   BSD license, all text above must be included in any redistribution
  ****************************************************/
 
+/* Additional usage information:
+ * This library reads the sensor in high reliability single shot mode,
+ * which takes 500ms.  It always reads both temperature and humidity in
+ * one reading.  After calling either of the read functions, assuming
+ * it does not return NaN, the previous value function will return valid
+ * data from the same reading.
+ *
+ * The sensor also supports less accurate but faster modes as well
+ * as a periodic data acquisition mode, and alerts, which are not
+ * implemented by this library.
+ */
+
 #if (ARDUINO >= 100)
  #include "Arduino.h"
 #else
@@ -40,6 +52,8 @@ class Adafruit_SHT31 {
   boolean begin(uint8_t i2caddr = SHT31_DEFAULT_ADDR);
   float readTemperature(void);
   float readHumidity(void);
+  float previousTemperature(void) { return temp; }
+  float previousHumidity(void) { return humidity; }
   uint16_t readStatus(void);
   void reset(void);
   void heater(boolean);

--- a/examples/SHT31test/SHT31test.ino
+++ b/examples/SHT31test/SHT31test.ino
@@ -34,18 +34,13 @@ void setup() {
 
 void loop() {
   float t = sht31.readTemperature();
-  float h = sht31.readHumidity();
+  float h = sht31.previousHumidity();
 
   if (! isnan(t)) {  // check if 'is not a number'
     Serial.print("Temp *C = "); Serial.println(t);
-  } else { 
-    Serial.println("Failed to read temperature");
-  }
-  
-  if (! isnan(h)) {  // check if 'is not a number'
     Serial.print("Hum. % = "); Serial.println(h);
   } else { 
-    Serial.println("Failed to read humidity");
+    Serial.println("Failed to read sensor");
   }
   Serial.println();
   delay(1000);


### PR DESCRIPTION
Added previous\* functions, which allow reading both sensors in half a
second instead of making two readings.  This could be important for
either speed or using coordinated readings.

Added additional usage documentation to the header file
including some hints from the data sheet.

Updated the example to use one of the new functions.
