### PR TITLE
Put header file processing in #ifndef

### DIFF
--- a/Adafruit_SHT31.h
+++ b/Adafruit_SHT31.h
@@ -14,6 +14,8 @@
   BSD license, all text above must be included in any redistribution
  ****************************************************/
 
+#ifndef ADAFRUIT_SHT31_H
+#define ADAFRUIT_SHT31_H
 #if (ARDUINO >= 100)
  #include "Arduino.h"
 #else
@@ -54,3 +56,4 @@ class Adafruit_SHT31 {
   float humidity, temp;
 };
 
+#endif


### PR DESCRIPTION
Allow the header file to included multiple times (like a header file),
which is included in main sketch which also includes it.

Add #ifndef/#define/#endif bracket inside header file, like most other
Adafruit libraries.