### PR TITLE
forward declaration for Wire and use indirect reference to wire

### DIFF
--- a/Adafruit_SHT31.cpp
+++ b/Adafruit_SHT31.cpp
@@ -15,14 +15,15 @@
 
 #include "Adafruit_SHT31.h"
 
-Adafruit_SHT31::Adafruit_SHT31() {
+Adafruit_SHT31::Adafruit_SHT31(TwoWire *theWire) {
+  _wire = theWire;
   _i2caddr = NULL;
   humidity = 0.0f;
   temp = 0.0f;
 }
 
 boolean Adafruit_SHT31::begin(uint8_t i2caddr) {
-  Wire.begin();
+  _wire->begin();
   _i2caddr = i2caddr;
   reset();
   // return (readStatus() == 0x40);
@@ -31,10 +32,10 @@ boolean Adafruit_SHT31::begin(uint8_t i2caddr) {
 
 uint16_t Adafruit_SHT31::readStatus(void) {
   writeCommand(SHT31_READSTATUS);
-  Wire.requestFrom(_i2caddr, (uint8_t)3);
-  uint16_t stat = Wire.read();
+  _wire->requestFrom(_i2caddr, (uint8_t)3);
+  uint16_t stat = _wire->read();
   stat <<= 8;
-  stat |= Wire.read();
+  stat |= _wire->read();
   // Serial.println(stat, HEX);
   return stat;
 }
@@ -71,11 +72,11 @@ boolean Adafruit_SHT31::readTempHum(void) {
   writeCommand(SHT31_MEAS_HIGHREP);
 
   delay(20);
-  Wire.requestFrom(_i2caddr, (uint8_t)6);
-  if (Wire.available() != 6)
+  _wire->requestFrom(_i2caddr, (uint8_t)6);
+  if (_wire->available() != 6)
     return false;
   for (uint8_t i = 0; i < 6; i++) {
-    readbuffer[i] = Wire.read();
+    readbuffer[i] = _wire->read();
     //  Serial.print("0x"); Serial.println(readbuffer[i], HEX);
   }
 
@@ -112,10 +113,10 @@ boolean Adafruit_SHT31::readTempHum(void) {
 }
 
 void Adafruit_SHT31::writeCommand(uint16_t cmd) {
-  Wire.beginTransmission(_i2caddr);
-  Wire.write(cmd >> 8);
-  Wire.write(cmd & 0xFF);
-  Wire.endTransmission();
+  _wire->beginTransmission(_i2caddr);
+  _wire->write(cmd >> 8);
+  _wire->write(cmd & 0xFF);
+  _wire->endTransmission();
 }
 
 uint8_t Adafruit_SHT31::crc8(const uint8_t *data, int len) {

--- a/Adafruit_SHT31.cpp
+++ b/Adafruit_SHT31.cpp
@@ -15,6 +15,11 @@
 
 #include "Adafruit_SHT31.h"
 
+/*!
+ * @brief  SHT31 constructor using i2c
+ * @param  *theWire
+ *         optional wire
+ */
 Adafruit_SHT31::Adafruit_SHT31(TwoWire *theWire) {
   _wire = theWire;
   _i2caddr = NULL;

--- a/Adafruit_SHT31.h
+++ b/Adafruit_SHT31.h
@@ -32,6 +32,9 @@
 #define SHT31_HEATEREN             0x306D
 #define SHT31_HEATERDIS            0x3066
 
+//  Forward declarations of Wire for board/variant combinations that don't have a default 'Wire'
+extern TwoWire Wire;
+
 /**
  * Driver for the Adafruit SHT31-D Temperature and Humidity breakout board.
  */
@@ -40,7 +43,7 @@ class Adafruit_SHT31 {
         /**
          *  Constructor.
          */
-        Adafruit_SHT31();
+        Adafruit_SHT31(TwoWire *theWire = &Wire);
 
         /**
          * Initialises the I2C bus, and assigns the I2C address to us.
@@ -93,6 +96,8 @@ class Adafruit_SHT31 {
          * @return The computed CRC8 value.
          */
         uint8_t crc8(const uint8_t *data, int len);
+
+        TwoWire *_wire; /**< Wire object */
 
     private:
         /**


### PR DESCRIPTION
The SHT31 library uses a direct reference to the Wire interface and therefore does not allow the user to use a different Wire interface (such as Wire1, Wire2, etc).

This PR changes the direct reference and uses an indirect reference.  The user can specify the required wire interface in the constructor when creating the object.  The changes here are modelled from the Adafruit BMP280 library.

A forward declaration is also provided for the case where WIRE_INTERFACES_COUNT == 0.