### PR TITLE
fix compiler warning: converting type

### DIFF
--- a/Adafruit_SHT31.cpp
+++ b/Adafruit_SHT31.cpp
@@ -22,7 +22,7 @@
  */
 Adafruit_SHT31::Adafruit_SHT31(TwoWire *theWire) {
   _wire = theWire;
-  _i2caddr = NULL;
+  _i2caddr = 0;
   humidity = 0.0f;
   temp = 0.0f;
 }


### PR DESCRIPTION
`NULL` can not be used for type `uint8_t`.

> warning: converting to non-pointer type 'uint8_t {aka unsigned char}' from NULL [-Wconversion-null]