### PR TITLE
Added support for checking sensor heater, fixed issues when issuing h…

### DIFF
--- a/Adafruit_SHT31.cpp
+++ b/Adafruit_SHT31.cpp
@@ -69,6 +69,16 @@ void Adafruit_SHT31::heater(bool h) {
     writeCommand(SHT31_HEATEREN);
   else
     writeCommand(SHT31_HEATERDIS);
+  delay(1); 
+}
+
+/*! 
+ *  @brief  Return sensor heater state 
+ *  @return heater state (TRUE = enabled, FALSE = disabled) 
+ */ 
+bool Adafruit_SHT31::isHeaterEnabled() { 
+  uint16_t regValue = readStatus(); 
+  return (bool)bitRead(regValue, SHT31_REG_HEATER_BIT); 
 }
 
 float Adafruit_SHT31::readTemperature(void) {

--- a/Adafruit_SHT31.h
+++ b/Adafruit_SHT31.h
@@ -41,6 +41,7 @@
 #define SHT31_SOFTRESET 0x30A2   /**< Soft Reset */
 #define SHT31_HEATEREN 0x306D    /**< Heater Enable */
 #define SHT31_HEATERDIS 0x3066   /**< Heater Disable */
+#define SHT31_REG_HEATER_BIT 0x0d /**< Status Register Heater Bit */
 
 extern TwoWire Wire; /**< Forward declarations of Wire for board/variant
                         combinations that don't have a default 'Wire' */
@@ -96,6 +97,13 @@ public:
    * @param h True to enable the heater, False to disable it.
    */
   void heater(bool h);
+
+  /**
+   * Gets the current status register heater bit.
+   *
+   * @return Boolean value, True = enabled, False = disabled.
+   */
+  bool isHeaterEnabled();
 
   TwoWire *_wire; /**< Wire object */
 

--- a/examples/SHT31test/SHT31test.ino
+++ b/examples/SHT31test/SHT31test.ino
@@ -12,6 +12,9 @@
 #include <Wire.h>
 #include "Adafruit_SHT31.h"
 
+bool enableHeater = false;
+uint8_t loopCnt = 0;
+
 Adafruit_SHT31 sht31 = Adafruit_SHT31();
 
 void setup() {
@@ -25,6 +28,12 @@ void setup() {
     Serial.println("Couldn't find SHT31");
     while (1) delay(1);
   }
+
+  Serial.print("Heater Enabled State: ");
+  if (sht31.isHeaterEnabled())
+    Serial.println("ENABLED");
+  else
+    Serial.println("DISABLED");
 }
 
 
@@ -33,7 +42,7 @@ void loop() {
   float h = sht31.readHumidity();
 
   if (! isnan(t)) {  // check if 'is not a number'
-    Serial.print("Temp *C = "); Serial.println(t);
+    Serial.print("Temp *C = "); Serial.print(t); Serial.print("\t\t");
   } else { 
     Serial.println("Failed to read temperature");
   }
@@ -43,6 +52,20 @@ void loop() {
   } else { 
     Serial.println("Failed to read humidity");
   }
-  Serial.println();
+
   delay(1000);
+
+  // Toggle heater enabled state every 30 seconds
+  // An ~3.0 degC temperature increase can be noted when heater is enabled
+  if (++loopCnt == 30) {
+    enableHeater = !enableHeater;
+    sht31.heater(enableHeater);
+    Serial.print("Heater Enabled State: ");
+    if (sht31.isHeaterEnabled())
+      Serial.println("ENABLED");
+    else
+      Serial.println("DISABLED");
+
+    loopCnt = 0;
+  }
 }


### PR DESCRIPTION
…eater commands.

Added method for checking sensor heater status.
Added 1ms delay after issuing a heater command to prevent the Teensy board from hanging during the next command and corrupting the status register (setting to 0xffff) for the other boards tested (except for the Metro 328).

Tested on the following boards using the updated example INO file in the PlatformIO environment:
 - Adafruit Feather HUZZAH
 - Adafruit HUZZAH32
 - Adafruit Feather M4 Express
 - Adafruit Grand Central M4 Express
 - Teensy 4.0
 - Adafruit METRO 328
