### PR TITLE
Temperature conversion formula

### DIFF
--- a/Adafruit_SHT31.cpp
+++ b/Adafruit_SHT31.cpp
@@ -189,6 +189,8 @@ bool Adafruit_SHT31::readTempHum(void) {
   int32_t stemp = (int32_t)(((uint32_t)readbuffer[0] << 8) | readbuffer[1]);
   // simplified (65536 instead of 65535) integer version of:
   // temp = (stemp * 175.0f) / 65535.0f - 45.0f;
+  stemp = ((175.0f * (float)stemp) / 65535.0f) - 45.0f;
+  temp = (float)stemp;
   stemp = ((4375 * stemp) >> 14) - 4500;
   temp = (float)stemp / 100.0f;
 

--- a/Adafruit_SHT31.cpp
+++ b/Adafruit_SHT31.cpp
@@ -191,8 +191,6 @@ bool Adafruit_SHT31::readTempHum(void) {
   // temp = (stemp * 175.0f) / 65535.0f - 45.0f;
   stemp = ((175.0f * (float)stemp) / 65535.0f) - 45.0f;
   temp = (float)stemp;
-  stemp = ((4375 * stemp) >> 14) - 4500;
-  temp = (float)stemp / 100.0f;
 
   uint32_t shum = ((uint32_t)readbuffer[3] << 8) | readbuffer[4];
   // simplified (65536 instead of 65535) integer version of:


### PR DESCRIPTION
Hello team,

First time for me doing a pull request, so please be gentle with me ;)

I'm experiencing some temperature differences between sensors I already have my room and a project I currently have for controlling my HVAC.  The difference was about ~1°C. I have a baby temperature sensor and a Xiaomi Temp sensor v2 (that also use SHT31 sensor) 
First I suspected my sensor location in the box I made. But whatever the position (outside the box, in the box near the screen, far from the screen) the temperature was alway upper by ~1°C.
I finally checked the SHT31-D datasheet and discover that the conversion formula was not the same in the library.
I replaced the current formula by the one in the datasheet and now the temperature works like a charm.

Hope this modification can help everyone.
See you,
Max