### PR TITLE
Allow returning temperature and humidity from the same call

### DIFF
--- a/Adafruit_SHT31.cpp
+++ b/Adafruit_SHT31.cpp
@@ -136,6 +136,22 @@ float Adafruit_SHT31::readHumidity(void) {
 }
 
 /**
+ * Gets a reading of both temperature and relative humidity from the sensor.
+ *
+ * @param temperature_out  Where to write the temperature float.
+ * @param humidity_out     Where to write the relative humidity float.
+ */
+void Adafruit_SHT31::readBoth(float *temperature_out, float *humidity_out) {
+  if (!readTempHum()) {
+    *temperature_out = *humidity_out = NAN;
+    return;
+  }
+
+  *temperature_out = temp;
+  *humidity_out = humidity;
+}
+
+/**
  * Performs a CRC8 calculation on the supplied values.
  *
  * @param data  Pointer to the data to use when calculating the CRC8.

--- a/Adafruit_SHT31.h
+++ b/Adafruit_SHT31.h
@@ -56,6 +56,7 @@ public:
   bool begin(uint8_t i2caddr = SHT31_DEFAULT_ADDR);
   float readTemperature(void);
   float readHumidity(void);
+  void readBoth(float *temperature_out, float *humidity_out);
   uint16_t readStatus(void);
   void reset(void);
   void heater(bool h);


### PR DESCRIPTION
The underlying sensor call (and therefore readTempHum()) returns both a
temperature and a humidity to each request.  However, with the current
interface, if a caller wants *both* the temperature and humidity, this
necessarily requires two readTempHum() calls, since both
readTemperature() and readHumidity() call readTempHum().

Add a new function readBoth() to return both values at once, which saves
a trip through readTempHum().

---

This introduces a new function and does not touch existing functions, so I believe the risk is low.  It appears to build okay with the Arduino IDE.

I considered adjusting readTemperature() and readHumidity() to call the new function, but thought that might be too invasive (and not really gain anything as an add-on) - and deleting the existing functions would break compatibility.

I also considered not adding a new function at all and instead having readHumidity() and readTemperature() just use the cached values if they're called "close together" in time, but didn't come up with a way of doing that that I liked.  However, such an approach would avoid the use of pointers, if that's a goal.