### PR TITLE
Add destructor to free memory in use

### DIFF
--- a/Adafruit_SHT31.cpp
+++ b/Adafruit_SHT31.cpp
@@ -44,12 +44,11 @@ Adafruit_SHT31::Adafruit_SHT31(TwoWire *theWire) {
 /**
  * Destructor to free memory in use.
  */
-Adafruit_SHT31::~Adafruit_SHT31(){
+Adafruit_SHT31::~Adafruit_SHT31() {
   if (i2c_dev) {
     delete i2c_dev; // remove old interface
   }
 }
-
 
 /**
  * Initialises the I2C bus, and assigns the I2C address to us.

--- a/Adafruit_SHT31.cpp
+++ b/Adafruit_SHT31.cpp
@@ -42,6 +42,16 @@ Adafruit_SHT31::Adafruit_SHT31(TwoWire *theWire) {
 }
 
 /**
+ * Destructor to free memory in use.
+ */
+Adafruit_SHT31::~Adafruit_SHT31(){
+  if (i2c_dev) {
+    delete i2c_dev; // remove old interface
+  }
+}
+
+
+/**
  * Initialises the I2C bus, and assigns the I2C address to us.
  *
  * @param i2caddr   The I2C address to use for the sensor.

--- a/Adafruit_SHT31.h
+++ b/Adafruit_SHT31.h
@@ -52,6 +52,7 @@ extern TwoWire Wire; /**< Forward declarations of Wire for board/variant
 class Adafruit_SHT31 {
 public:
   Adafruit_SHT31(TwoWire *theWire = &Wire);
+  ~Adafruit_SHT31();
 
   bool begin(uint8_t i2caddr = SHT31_DEFAULT_ADDR);
   float readTemperature(void);


### PR DESCRIPTION
Add destructor to free memory. Fixes memory leak when an instance is repeatedly constructed and begin is called.
