### PR TITLE
Fix #36: make boolean read success/fail accessible

### DIFF
--- a/Adafruit_SHT31.cpp
+++ b/Adafruit_SHT31.cpp
@@ -203,7 +203,7 @@ bool Adafruit_SHT31::readTempHum(void) {
   uint8_t readbuffer[6];
 
   if (!writeCommand(SHT31_MEAS_HIGHREP))
-    return false;;
+    return false;
 
   delay(20);
 

--- a/Adafruit_SHT31.cpp
+++ b/Adafruit_SHT31.cpp
@@ -202,12 +202,12 @@ static uint8_t crc8(const uint8_t *data, int len) {
 bool Adafruit_SHT31::readTempHum(void) {
   uint8_t readbuffer[6];
 
-  if ( !writeCommand(SHT31_MEAS_HIGHREP) )
+  if (!writeCommand(SHT31_MEAS_HIGHREP))
     return false;;
 
   delay(20);
 
-  if ( !i2c_dev->read(readbuffer, sizeof(readbuffer)) )
+  if (!i2c_dev->read(readbuffer, sizeof(readbuffer)))
     return false;
 
   if (readbuffer[2] != crc8(readbuffer, 2) ||

--- a/Adafruit_SHT31.cpp
+++ b/Adafruit_SHT31.cpp
@@ -150,14 +150,15 @@ float Adafruit_SHT31::readHumidity(void) {
  * @param temperature_out  Where to write the temperature float.
  * @param humidity_out     Where to write the relative humidity float.
  */
-void Adafruit_SHT31::readBoth(float *temperature_out, float *humidity_out) {
+bool Adafruit_SHT31::readBoth(float *temperature_out, float *humidity_out) {
   if (!readTempHum()) {
     *temperature_out = *humidity_out = NAN;
-    return;
+    return false;
   }
 
   *temperature_out = temp;
   *humidity_out = humidity;
+  return true;
 }
 
 /**
@@ -201,11 +202,13 @@ static uint8_t crc8(const uint8_t *data, int len) {
 bool Adafruit_SHT31::readTempHum(void) {
   uint8_t readbuffer[6];
 
-  writeCommand(SHT31_MEAS_HIGHREP);
+  if ( !writeCommand(SHT31_MEAS_HIGHREP) )
+    return false;;
 
   delay(20);
 
-  i2c_dev->read(readbuffer, sizeof(readbuffer));
+  if ( !i2c_dev->read(readbuffer, sizeof(readbuffer)) )
+    return false;
 
   if (readbuffer[2] != crc8(readbuffer, 2) ||
       readbuffer[5] != crc8(readbuffer + 3, 2))

--- a/Adafruit_SHT31.cpp
+++ b/Adafruit_SHT31.cpp
@@ -149,6 +149,7 @@ float Adafruit_SHT31::readHumidity(void) {
  *
  * @param temperature_out  Where to write the temperature float.
  * @param humidity_out     Where to write the relative humidity float.
+ * @return True if the read was successful, false otherwise
  */
 bool Adafruit_SHT31::readBoth(float *temperature_out, float *humidity_out) {
   if (!readTempHum()) {

--- a/Adafruit_SHT31.h
+++ b/Adafruit_SHT31.h
@@ -57,7 +57,7 @@ public:
   bool begin(uint8_t i2caddr = SHT31_DEFAULT_ADDR);
   float readTemperature(void);
   float readHumidity(void);
-  void readBoth(float *temperature_out, float *humidity_out);
+  bool readBoth(float *temperature_out, float *humidity_out);
   uint16_t readStatus(void);
   void reset(void);
   void heater(bool h);


### PR DESCRIPTION
Allows the user to determine whether a request to read temperature and humidity values has succeeded or failed without 
  a) having to do expensive floating point comparisons, and 
  b) risking passing along invalid data due to performing checks on uninitialized data

This approach could probably applied to the other control and status calls, but that's out of scope for this bugfix.

